### PR TITLE
Replace deprecated unpexpected-react-shallow with unexpected-react

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/sapegin/expect-react-shallow.svg)](https://travis-ci.org/sapegin/expect-react-shallow)
 
-A [Chai’s](http://chaijs.com) expect like API wrapper for [unexpected-react-shallow](https://github.com/bruderstein/unexpected-react-shallow). It also accepts JSX instead of ShallowRenderer instance.
+A [Chai’s](http://chaijs.com) expect like API wrapper for [unexpected-react](https://github.com/bruderstein/unexpected-react). It also accepts JSX instead of ShallowRenderer instance.
 
 ![expect-react-shallow](https://s3.amazonaws.com/f.cl.ly/items/1M3a3B163l392G1N3v25/Screen%20Shot%202015-11-12%20at%2022.39.57.png)
 
@@ -62,9 +62,12 @@ expectReactShallow(ReactComponent|JSX).to.have.exactly.rendered(ReactComponent|J
 expectReactShallow(ReactComponent|JSX).to.contain(ReactComponent|JSX);
 expectReactShallow(ReactComponent|JSX).to.contain.exactly(ReactComponent|JSX);
 expectReactShallow(ReactComponent|JSX).to.contain.with.all.children(ReactComponent|JSX);
+expectReactShallow(ReactComponent|JSX).to.not.contain(ReactComponent|JSX);
+expectReactShallow(ReactComponent|JSX).to.not.contain.exactly(ReactComponent|JSX);
+expectReactShallow(ReactComponent|JSX).to.not.contain.with.all.children(ReactComponent|JSX);
 ```
 
-See details in [unexpected-react-shallow docs](https://github.com/bruderstein/unexpected-react-shallow#assertions).
+See details in [unexpected-react docs](https://github.com/bruderstein/unexpected-react#assertions).
 
 
 ## Changelog

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
 var TestUtils = require('react-addons-test-utils');
 var unexpected = require('unexpected');
-var unexpectedReactShallow = require('unexpected-react-shallow');
+var unexpectedReact = require('unexpected-react');
 
-var expectShallowRender = unexpected.clone().installPlugin(unexpectedReactShallow);
+var expectShallowRender = unexpected.clone().installPlugin(unexpectedReact);
 
 function getShallowRenderer(jsx) {
 	var renderer = TestUtils.createRenderer();
@@ -19,6 +19,11 @@ function expectShallow(jsx) {
 		to: {
 			have: {
 				exactly: {}
+			},
+			not: {
+				have: {
+					exactly: {}
+				}
 			}
 		}
 	};
@@ -31,6 +36,10 @@ function expectShallow(jsx) {
 	api.to.contain.exactly = run.bind(null, 'to contain exactly');
 	api.to.contain.with = {all: {}};
 	api.to.contain.with.all.children = run.bind(null, 'to contain with all children');
+	api.to.not.contain = run.bind(null, 'not to contain');
+	api.to.not.contain.exactly = run.bind(null, 'not to contain exactly');
+	api.to.not.contain.with = {all: {}};
+	api.to.not.contain.with.all.children = run.bind(null, 'not to contain with all children');
 
 	return api;
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expect-react-shallow",
   "version": "1.1.0",
-  "description": "JSX assertions with Chai-like API (based on unexpected-react-shallow)",
+  "description": "JSX assertions with Chai-like API (based on unexpected-react)",
   "main": "lib/index.js",
   "scripts": {
     "test": "npm run lint && npm run mocha",
@@ -40,7 +40,7 @@
   "dependencies": {
     "react-addons-test-utils": "~0.14.2",
     "unexpected": "~10.1.0",
-    "unexpected-react-shallow": "~0.7.0"
+    "unexpected-react": "^1.0.0"
   },
   "devDependencies": {
     "babel-core": "~6.1.4",

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,10 @@ describe('expectReactShallow', () => {
 			expect(api.to.contain).to.be.a.func;
 			expect(api.to.contain.exactly).to.be.a.func;
 			expect(api.to.contain.with.all.children).to.be.a.func;
+			expect(api.to.not.contain).to.be.a.func;
+			expect(api.to.not.contain.exactly).to.be.a.func;
+			expect(api.to.not.contain.with).to.be.a.func;
+			expect(api.to.not.contain.with.all.children).to.be.a.func;
 		});
 
 	});
@@ -112,6 +116,51 @@ describe('expectReactShallow', () => {
 		it('should throw an error if the JSX not contains another JSX with all children', () => {
 			expect(
 				() => expectReactShallow(<TestComponent/>).to.contain.with.all.children(<div/>)
+			).to.throw();
+		});
+
+	});
+
+	describe('expectReactShallow().to.not.contain()', () => {
+
+		it('should not throw an error if the JSX contains another JSX', () => {
+			expect(
+				() => expectReactShallow(<TestComponent/>).to.not.contain(<span/>)
+			).to.not.throw();
+		});
+		it('should throw an error if the JSX not contains another JSX', () => {
+			expect(
+				() => expectReactShallow(<TestComponent/>).to.not.contain(<div/>)
+			).to.throw();
+		});
+
+	});
+
+	describe('expectReactShallow().to.not.contain.exactly()', () => {
+
+		it('should not throw an error if the JSX contains exactly another JSX', () => {
+			expect(
+				() => expectReactShallow(<TestComponent/>).to.not.contain.exactly(<div>Hello React!</div>)
+			).to.not.throw();
+		});
+		it('should throw an error if the JSX not contains exactly another JSX', () => {
+			expect(
+				() => expectReactShallow(<TestComponent/>).to.not.contain.exactly(<div className="foo">Hello React!</div>)
+			).to.throw();
+		});
+
+	});
+
+	describe('expectReactShallow().to.not.contain.with.all.children()', () => {
+
+		it('should not throw an error if the JSX contains another JSX with all children', () => {
+			expect(
+				() => expectReactShallow(<TestComponent/>).to.not.contain.with.all.children(<div/>)
+			).to.not.throw();
+		});
+		it('should throw an error if the JSX not contains another JSX with all children', () => {
+			expect(
+				() => expectReactShallow(<TestComponent/>).to.not.contain.with.all.children(<div className="foo">Hello React!</div>)
 			).to.throw();
 		});
 


### PR DESCRIPTION
The `unexpected-react-shallow` library will be deprecated soonish, according to this comment from the author (https://github.com/bruderstein/unexpected-react-shallow/issues/10#issuecomment-169074047):

> I'll be deprecating this library in favour of unexpected-react shortly....Once the new version of unexpected-react is released, I'll deprecate this library.

The new version has been released as of a few days ago.

This pull request updates `expect-react-shallow` to utilize the new library.  It also adds support for using `not` with the contain tests.  For example:

```
expectReactShallow(<TestComponent/>).to.not.contain(<span/>)
```

This pull request should follow everything outlined in `Contributing.md`, but let me know if I missed something :)
