### PR TITLE
add support for latest version of unexpected-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expect-react-shallow",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "JSX assertions with Chai-like API (based on unexpected-react)",
   "main": "lib/index.js",
   "scripts": {
@@ -35,12 +35,13 @@
     "node": ">=0.12.0"
   },
   "peerDependencies": {
-    "react": ">=0.14.0"
+    "react": ">=0.14.0",
+    "react-dom": ">=0.14.0"
   },
   "dependencies": {
-    "react-addons-test-utils": "~0.14.2",
+    "react-addons-test-utils": ">=0.14.2",
     "unexpected": "~10.1.0",
-    "unexpected-react": "~1.0.0"
+    "unexpected-react": ">=1.0.0"
   },
   "devDependencies": {
     "babel-core": "~6.1.4",
@@ -49,6 +50,7 @@
     "chai": "~3.4.1",
     "eslint": "~1.9.0",
     "mocha": "~2.3.3",
-    "react": "~0.14.2"
+    "react": ">=0.14.2",
+    "react-dom": ">=0.14.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expect-react-shallow",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "description": "JSX assertions with Chai-like API (based on unexpected-react)",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
- upgrade unexpected-react
- add react-dom to peerDependencies(required by latest version of unexpected-react)
- allow v15 version of react-addons-test-utils
- allow tests(devDependencies) to run on latest version of react
